### PR TITLE
docs: fix plugin install name in README (superpowers → superpowers-deepseek-v4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ From a clone of this repository, register the local marketplace and install the 
 ```bash
 cd /path/to/superpowers-deepseek-v4
 /plugin marketplace add ./
-/plugin install superpowers@gylove1994-superpowers-deepseek-v4 --scope project
+/plugin install superpowers-deepseek-v4@gylove1994-superpowers-deepseek-v4 --scope project
 ```
 
 Or add `--scope user` if you want it available in every project.


### PR DESCRIPTION
## What problem are you trying to solve?

A user following the README install instructions for Claude Code runs:

```
/plugin install superpowers@gylove1994-superpowers-deepseek-v4 --scope project
```

This fails the `plugin.json` in this repo registers the plugin as `superpowers-deepseek-v4`:

https://github.com/gylove1994/superpowers-deepseek-v4/blob/main/.claude-plugin/plugin.json#L2

The install command must match the registered name: `superpowers-deepseek-v4@gylove1994-superpowers-deepseek-v4`.

## What does this PR change?

Changes the plugin name in the Claude Code install command from `superpowers@` to `superpowers-deepseek-v4@` on line 24 of README.md.

## Is this change appropriate for Superpowers DeepSeek v4?

- **Would it still make sense for someone on a completely different project?** Yes — every new user of this fork hits this instruction.
- **Is it specific to a tool or domain?** No, it fixes the primary install path for the Claude Code harness.
- **Could this live in a separate plugin?** No, it is a one-word correction to the README of this repo.
- **Is this solving a real user experience?** Yes — users copy-pasting the current command get a broken install.

## What alternatives did you consider?

The alternative is leaving the wrong name and having every new user debug the install failure themselves. This is the minimal fix — one word changed to match the actual plugin name in plugin.json.

## Does this PR contain multiple unrelated changes?

No. One word changed, one file touched.

## Existing PRs

- [x] I have reviewed all open AND closed PRs for duplicates or prior art.

**Related PRs:** None found. This is a documentation-only fix; no prior PRs addressed this typo.

## Environment tested

| Harness | Harness version | Model | Model version/ID |
|---|---|---|---|
| Claude Code | latest (2.x) | n/a (docs only) | n/a (docs only) |

## New harness support

Not applicable — documentation-only change, no new harness.

## Evaluation

- **Initial prompt:** User reported the install command in the README does not match the plugin name in plugin.json.
- **Eval sessions after change:** 0 (documentation fix — no behavior change to evaluate)
- **Before/after:** Before: README says `superpowers@...` (wrong). After: README says `superpowers-deepseek-v4@...` (correct — matches plugin.json).

## Rigor

- [ ] I used `superpowers-deepseek-v4:writing-skills` to develop and test this change
- [ ] I ran adversarial pressure-testing across multiple sessions
- [ ] If I modified carefully-tuned content I supported every change with extensive evals

*Checkboxes intentionally unchecked — this is a one-word README correction. No skill content, behavior, or configuration was modified.*

## Human review

- [x] A human has reviewed the COMPLETE proposed diff before submission.